### PR TITLE
fix redundant await on requestLocale

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -2,7 +2,8 @@ import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
-   let locale = requestLocale;
+   // requestLocale is a Promise from next-intl so we need to await it
+   let locale = await requestLocale;
 
    if (!locale || !routing.locales.includes(locale as any)) {
       locale = routing.defaultLocale;

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -2,7 +2,7 @@ import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
 
 export default getRequestConfig(async ({requestLocale}) => {
-   let locale = await requestLocale;
+   let locale = requestLocale;
 
    if (!locale || !routing.locales.includes(locale as any)) {
       locale = routing.defaultLocale;


### PR DESCRIPTION
## Summary
- remove an unnecessary `await` when assigning `requestLocale`

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run i18n:check` *(fails: `next-intl` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875d4b5b800832f981b61ee1cd18ec1